### PR TITLE
Fixed issues with arguments to formatting function printf.

### DIFF
--- a/lib/psdriver/draw_bitmap.c
+++ b/lib/psdriver/draw_bitmap.c
@@ -4,7 +4,7 @@ void PS_Bitmap(int ncols, int nrows, int threshold, const unsigned char *buf)
 {
     int i, j;
 
-    output("%d %d %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
+    output("%lf %lf %d %d BITMAP\n", cur_x, cur_y, ncols, nrows);
 
     for (j = 0; j < nrows; j++) {
         unsigned int bit = 0x80;

--- a/lib/psdriver/erase.c
+++ b/lib/psdriver/erase.c
@@ -3,7 +3,7 @@
 void PS_Erase(void)
 {
     if (ps.encapsulated)
-        output("%d %d %d %d BOX\n", ps.left, ps.top, ps.right, ps.bot);
+        output("%lf %lf %lf %lf BOX\n", ps.left, ps.top, ps.right, ps.bot);
     else
         output("ERASE\n");
 }


### PR DESCRIPTION
Each call to the printf function or a related function should include the type and sequence of arguments defined by the format. If the function is passed arguments of a different type or in a different sequence then the arguments are reinterpreted to fit the type and sequence expected, resulting in unpredictable behavior.

Changed files had doubles being passed to integer formatting, changed to double formatting.